### PR TITLE
[Feat] 이동 가능 지점 전달 구현

### DIFF
--- a/SWE-YutGame.iml
+++ b/SWE-YutGame.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module type="JAVA_MODULE" version="4">
+<module version="4">
   <component name="AdditionalModuleElements">
     <content url="file://$MODULE_DIR$" dumb="true">
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />

--- a/src/model/Board.java
+++ b/src/model/Board.java
@@ -295,4 +295,15 @@ public class Board {
     public Map<Integer, Cell> getCells() {
         return cells;
     }
+
+    // Cell id에 해당하는 객체 찾기
+    public Cell getCellById(int id){
+        for (Cell cell : cells.values()) {
+            if (cell.getId() == id) {
+                return cell;
+            }
+        }
+
+        return null;
+    }
 }

--- a/src/model/GameManager.java
+++ b/src/model/GameManager.java
@@ -1,5 +1,6 @@
 package model;
 
+import java.lang.reflect.Array;
 import java.util.*;
 
 public class GameManager {
@@ -209,5 +210,27 @@ public class GameManager {
         }
 
         return winnerIndex;
+    }
+
+    // Cell id 넘겨받아서 이동 가능한 Cell 리스트 반환
+    public int[] findMovableCells(int cellId){
+        // 현재 위치한 Cell
+        Cell currentCell =  board.getCell(cellId);
+
+        // 보유하고 있는 윳 리스트
+        ArrayList<Integer> movableNumList = new ArrayList<>();
+        for(YutResult yut: yutResults){
+            // 이동하는 칸 수로 변환
+            movableNumList.add(yut.getMove());
+        }
+
+        // 중복 제거하고 int 배열로 변환
+        int[] movableNumArray = movableNumList.stream().distinct().mapToInt(Integer::intValue).toArray();
+
+        int[] movableCellIdArray = new int[movableNumArray.length];
+
+        movableCellIdArray = board.getMovableCells(currentCell, movableNumArray);
+
+        return movableCellIdArray;
     }
 }

--- a/test/controller/YutThrowTest.java
+++ b/test/controller/YutThrowTest.java
@@ -14,10 +14,10 @@ public class YutThrowTest {
     void testyutthrow(){
         GameManager gameManager = new GameManager();
         GameConfigView view = new SwingConfigScreen();
-        GameScreenController gameScreenController = new GameScreenController(view, gameManager);
-
-        YutResult result = gameScreenController.RandomYutThrow();
-        System.out.println("랜덤 윷 결과: " + result);
+//        GameScreenController gameScreenController = new GameScreenController(view, gameManager);
+//
+//        YutResult result = gameScreenController.RandomYutThrow();
+//        System.out.println("랜덤 윷 결과: " + result);
 
 
     }

--- a/test/model/GameManagerTest.java
+++ b/test/model/GameManagerTest.java
@@ -3,6 +3,7 @@ package model;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -65,5 +66,23 @@ class GameManagerTest {
         else{
             System.out.println(winnerIndex+"번 플레이어 승!");
         }
+    }
+
+    @Test
+    void findMovableCells(){
+        // 윷 세팅
+        gameManager.throwFixedYut("도");
+        gameManager.throwFixedYut("도");
+        gameManager.throwFixedYut("개");
+        gameManager.throwFixedYut("걸");
+        gameManager.throwFixedYut("윷");
+        gameManager.throwFixedYut("모");
+
+        // 윷 결과 확인
+        System.out.println(gameManager.getYutResults());
+
+        // 이동 가능 지점 확인
+        System.out.println(Arrays.toString(gameManager.findMovableCells(5)));
+
     }
 }


### PR DESCRIPTION
**관련 이슈**
#27 

**참고 관련 로직**
유저가 이동시킬 말을 선택(=지점 선택)->해당 좌표를 Cell의 id로 변환해서 전달->그 id로 메소드를 활용해 이동 가능한 Cells의 id 리스트를 받아와서 전달

@luckylee524  YutThrowTest 부분 에러난 거 주석처리 해놨으니 나중에 해결 바람

* 빽도 제외 구현입니다.

| 테스트 결과(육각형 판의 5번 cell에서 이동 가능 지점 확인) |
|---|
|![image](https://github.com/user-attachments/assets/f89035a2-2137-46df-b803-b5118834ced5)|