### PR TITLE
[CHORE] 이동 가능 지점 정보 반환 구조 수정

### DIFF
--- a/src/model/GameManager.java
+++ b/src/model/GameManager.java
@@ -229,7 +229,7 @@ public class GameManager {
     }
 
     // Cell id 넘겨받아서 이동 가능한 Cell 리스트 반환
-    public int[] findMovableCells(int cellId){
+    public Map<Integer, Integer> findMovableCells(int cellId){
         // 현재 위치한 Cell
         Cell currentCell =  board.getCell(cellId);
 
@@ -245,8 +245,21 @@ public class GameManager {
 
         int[] movableCellIdArray = new int[movableNumArray.length];
 
-        movableCellIdArray = board.getMovableCells(currentCell, movableNumArray);
+        movableCellIdArray = board.getMovableCells(currentCell, movableNumArray); // 이동 가능 cell id list
 
-        return movableCellIdArray;
+        // ('이동 가능 cell id', '해당 cell로 가기 위해 이동해야 하는 칸 수')를 map 구조로 저장
+        Map<Integer, Integer> movableMap = new HashMap<>();
+
+        for(int i=0; i<movableCellIdArray.length; i++){
+            movableMap.put(movableCellIdArray[i], movableNumArray[i]);
+        }
+
+        // 중간 과정 디버깅용 출력
+        System.out.println("윷 리스트: " + yutResults.toString());
+        System.out.println("이동 가능 칸 수: " + movableNumList);
+        System.out.println("이동 가능 칸 수(중복 제거): " + Arrays.toString(movableNumArray));
+        System.out.println("이동 가능 지점 리스트: " + Arrays.toString(movableCellIdArray));
+
+        return movableMap;
     }
 }

--- a/test/model/GameManagerTest.java
+++ b/test/model/GameManagerTest.java
@@ -71,9 +71,9 @@ class GameManagerTest {
     @Test
     void findMovableCells(){
         // 윷 세팅
-        gameManager.throwFixedYut("도");
-        gameManager.throwFixedYut("도");
         gameManager.throwFixedYut("개");
+        gameManager.throwFixedYut("도");
+        gameManager.throwFixedYut("도");
         gameManager.throwFixedYut("걸");
         gameManager.throwFixedYut("윷");
         gameManager.throwFixedYut("모");
@@ -82,7 +82,8 @@ class GameManagerTest {
         System.out.println(gameManager.getYutResults());
 
         // 이동 가능 지점 확인
-        System.out.println(Arrays.toString(gameManager.findMovableCells(5)));
+        Map<Integer, Integer> movableMap = gameManager.findMovableCells(5);
+        System.out.println(movableMap);
 
     }
 }


### PR DESCRIPTION
**관련 이슈**
#35 

**결과**
![image](https://github.com/user-attachments/assets/ce3dfde2-685d-4357-a5ef-81052a4a1165)

**To Reviewer**
위의 예시로 이해 바람(육각형 판, 5번 cell 위치 가정)
이동 가능한 지점의 id 리스트 View로 전달->View에서 좌표로 변환해서 표시->유저가 클릭한 좌표 인식해서 cell id로 변환해서 전달
->get(cellId) 메소드 사용하면 해당 지점으로 가기 위해 몇 칸 이동하는 건지 확인 가능