### PR TITLE
[#51][FEATURE][UI] 화면에서 말 잡기와 말 업기 기능 구현

### DIFF
--- a/src/controller/GameScreenController.java
+++ b/src/controller/GameScreenController.java
@@ -202,8 +202,11 @@ public class GameScreenController {
         // 말 이동 후 extraTurn 상태가 true로 바뀌었다면 말을 잡았다는 의미
         boolean captureOccurred = !wasExtraTurn && gameManager.getExtraTurn();
 
-        // 업데이트된 말 위치를 화면에 반영 (캡처 포함)
+        // 업데이트된 말 위치 화면 표시
         gameView.repaintAllPieces();
+
+        // 말이 이동했으므로 파란색 테두리로 표시 제거 
+        gameView.clearPieceSelection();
 
         // 캡처 발생 시 메시지 표시
         if (captureOccurred) {
@@ -242,9 +245,7 @@ public class GameScreenController {
         updateYutResultsInView();
 
         // 윷 이미지 초기화
-        if (gameView instanceof SwingPlayScreen) {
-            ((SwingPlayScreen) gameView).clearYutImage();
-        }
+        gameView.clearYutImage();
 
         // 버튼 상태 초기화
         gameView.setThrowButtonEnabled(true);

--- a/src/controller/GameScreenController.java
+++ b/src/controller/GameScreenController.java
@@ -188,13 +188,27 @@ public class GameScreenController {
     public void selectCoordinate(int cellId){
         // 골라서 넘겨준 해시맵을 리스트에서 제거해야함. + 잡혔을 때 extraturn이 바뀌어 있는지 확인해야함.
         // 해시맵에서 선택했던 값만 추출
-
         Integer value = gameManager.getMovableMap().get(cellId);
 
         // 윷리스트에서 선택했던 값 삭제
         gameManager.removeYutResult(value);
+
+        // 현재 extraTurn 상태 저장 (말을 잡았는지 확인용)
+        boolean wasExtraTurn = gameManager.getExtraTurn();
+
         // 선택한 좌표로 말 이동
         gameManager.processYutResult(value);
+
+        // 말 이동 후 extraTurn 상태가 true로 바뀌었다면 말을 잡았다는 의미
+        boolean captureOccurred = !wasExtraTurn && gameManager.getExtraTurn();
+
+        // 업데이트된 말 위치를 화면에 반영 (캡처 포함)
+        gameView.repaintAllPieces();
+
+        // 캡처 발생 시 메시지 표시
+        if (captureOccurred) {
+            gameView.setStatusMessage("말을 잡았습니다! 한 번 더 던지세요.");
+        }
 
         if (gameManager.getExtraTurn()){
             // 윷버튼 활성화
@@ -202,9 +216,6 @@ public class GameScreenController {
         }
         else {
             if (gameManager.isYutResultsEmpty()) {
-                // 전체 상태 넘겨줘야함.
-                gameView.repaintAllPieces();
-
                 // 현재 턴 플레이어 확인 및 업데이트
                 int currentPlayer = gameManager.checkPlayer();
                 gameView.updateCurrentPlayer(currentPlayer);
@@ -213,13 +224,10 @@ public class GameScreenController {
                 gameView.setThrowButtonEnabled(true);
             }
             else {
-                // 일단 전체 상태를 넘겨주고
-                gameView.repaintAllPieces();
                 // 말선택 페이즈로 이동
                 gameView.enableWaitingPieceSelection();
             }
         }
-
     }
 
     // 게임 재시작

--- a/src/model/PositionDTO.java
+++ b/src/model/PositionDTO.java
@@ -41,6 +41,6 @@ public class PositionDTO {
     @Override
     public String toString() {
         // 테스트용 정보 출력
-        return playerId+"번 플레이어의 "+pieceId+"번 말은 "+cellId+"번 지점에 있습니다";
+        return playerId+"번 플레이어의 "+pieceId+"번 말은 "+cellId+"번 지점에 있습니다\n";
     }
 }

--- a/src/view/GamePlayView.java
+++ b/src/view/GamePlayView.java
@@ -79,4 +79,11 @@ public interface GamePlayView {
     // 게임 종료 화면 표시
     void showGameEndDialog(int winnerPlayer);
 
+
+    // 말이 윷판에 놓였을때 테두리 쳐지는 문제 해결
+    void clearPieceSelection();
+
+    // 윷 이미지 초기화
+    void clearYutImage();
+
 }

--- a/src/view/SwingPlayScreen.java
+++ b/src/view/SwingPlayScreen.java
@@ -60,6 +60,7 @@
 
 
         private Map<Integer, JPanel> playerPiecePanels = new HashMap<>();
+        private List<JLabel> stackCountLabels = new ArrayList<>();
 
 
 
@@ -849,13 +850,13 @@
         }
         
         // 말 전체 다시 그리기 메서드
-        public void repaintAllPieces(){
+        public void repaintAllPieces() {
             if(takeOutButtonListener == null) return;
 
             List<PositionDTO> currentPositions = takeOutButtonListener.onTakeOutButtonClicked();
             JPanel boardPanel = getBoardPanel();
 
-            // 윷 판에서 말 다 제거
+            // 보드에서 모든 말 제거
             for (Map.Entry<String, JLabel> entry : playerPiecesMap.entrySet()) {
                 JLabel pieceLabel = entry.getValue();
                 if (pieceLabel.getParent() == boardPanel) {
@@ -863,50 +864,118 @@
                 }
             }
 
-            // DTO 에서 위치 가져오기
+            // 이전에 생성된 업힌 말 표시 라벨들 모두 제거
+            for (JLabel label : stackCountLabels) {
+                if (label.getParent() != null) {
+                    label.getParent().remove(label);
+                }
+            }
+            stackCountLabels.clear();
+
+            // 먼저 대기 상태(-1)인 말들 처리 - 플레이어 패널로 돌려보내기
             for (PositionDTO dto : currentPositions) {
-                int playerId = dto.getPlayerId();
-                int pieceId = dto.getPieceId();
-                int cellId = dto.getCellId();
+                if (dto.getCellId() == -1) {
+                    int playerId = dto.getPlayerId();
+                    int pieceId = dto.getPieceId();
 
-                JLabel pieceLabel = playerPiecesMap.get(playerId + "_" + pieceId);
+                    JLabel pieceLabel = playerPiecesMap.get(playerId + "_" + pieceId);
+                    if (pieceLabel != null) {
+                        // 기존 부모에서 제거
+                        if (pieceLabel.getParent() != null) {
+                            pieceLabel.getParent().remove(pieceLabel);
+                        }
 
-                if (pieceLabel != null) {
-
-                    if (pieceLabel.getParent() != null) {
-                        pieceLabel.getParent().remove(pieceLabel);
-                    }
-
-                    if (cellId == -1) {
-
+                        // 플레이어 패널에 추가
                         JPanel piecePanel = playerPiecePanels.get(playerId);
                         if (piecePanel != null) {
                             piecePanel.add(pieceLabel);
-                        }
-                    } else {
-
-                        Point pos = squarePositionMap.get(cellId);
-                        if (pos != null) {
-                            pieceLabel.setBounds(pos.x - 5, pos.y - 35, 40, 40);
-                            boardPanel.add(pieceLabel);
-                            boardPanel.setComponentZOrder(pieceLabel, 0);
+                            piecePanel.revalidate();
+                            piecePanel.repaint();
                         }
                     }
                 }
             }
 
-
-            boardPanel.revalidate();
-            boardPanel.repaint();
-
-            for (JPanel panel : playerPiecePanels.values()) {
-                panel.revalidate();
-                panel.repaint();
+            // 이제 보드 위에 있는 말들 처리
+            // 각 셀별로 말 개수 카운트
+            Map<Integer, List<PositionDTO>> cellPieces = new HashMap<>();
+            for (PositionDTO dto : currentPositions) {
+                int cellId = dto.getCellId();
+                if (cellId != -1) { // -1은 대기 상태이므로 제외
+                    if (!cellPieces.containsKey(cellId)) {
+                        cellPieces.put(cellId, new ArrayList<>());
+                    }
+                    cellPieces.get(cellId).add(dto);
+                }
             }
 
+            // 보드에 말 배치 (동일 셀에 여러 말이 있을 경우 겹쳐 표시)
+            for (Map.Entry<Integer, List<PositionDTO>> entry : cellPieces.entrySet()) {
+                int cellId = entry.getKey();
+                List<PositionDTO> piecesAtCell = entry.getValue();
+                Point pos = squarePositionMap.get(cellId);
+
+                if (pos == null) continue;
+
+                // 말이 1개일 경우 일반 표시
+                if (piecesAtCell.size() == 1) {
+                    PositionDTO dto = piecesAtCell.get(0);
+                    JLabel pieceLabel = playerPiecesMap.get(dto.getPlayerId() + "_" + dto.getPieceId());
+
+                    if (pieceLabel != null) {
+                        pieceLabel.setBounds(pos.x - 5, pos.y - 35, 40, 40);
+                        boardPanel.add(pieceLabel);
+                        boardPanel.setComponentZOrder(pieceLabel, 0);
+                    }
+                }
+                // 말이 여러 개일 경우 (업혀있는 경우)
+                else if (piecesAtCell.size() > 1) {
+                    // 메인 말 위치 (첫 번째 말)
+                    PositionDTO mainDto = piecesAtCell.get(0);
+                    JLabel mainPieceLabel = playerPiecesMap.get(mainDto.getPlayerId() + "_" + mainDto.getPieceId());
+
+                    if (mainPieceLabel != null) {
+                        mainPieceLabel.setBounds(pos.x - 5, pos.y - 35, 40, 40);
+                        boardPanel.add(mainPieceLabel);
+                        boardPanel.setComponentZOrder(mainPieceLabel, 0);
+
+                        // 업힌 말 수 표시 라벨 생성
+                        JLabel stackCountLabel = new JLabel("+" + (piecesAtCell.size() - 1));
+                        stackCountLabel.setFont(new Font("SansSerif", Font.BOLD, 14));
+                        stackCountLabel.setForeground(Color.RED);
+                        stackCountLabel.setBackground(Color.WHITE);
+                        stackCountLabel.setOpaque(true);
+                        stackCountLabel.setBorder(BorderFactory.createLineBorder(Color.BLACK, 1));
+                        stackCountLabel.setBounds(pos.x + 15, pos.y - 35, 25, 20);
+                        boardPanel.add(stackCountLabel);
+                        boardPanel.setComponentZOrder(stackCountLabel, 0);
+
+                        // 생성한 라벨을 리스트에 추가하여 추적
+                        stackCountLabels.add(stackCountLabel);
+
+                        // 나머지 말들은 살짝 겹쳐서 표시 (시각적 효과)
+                        for (int i = 1; i < piecesAtCell.size() && i < 4; i++) { // 최대 3개까지만 표시
+                            PositionDTO dto = piecesAtCell.get(i);
+                            JLabel pieceLabel = playerPiecesMap.get(dto.getPlayerId() + "_" + dto.getPieceId());
+
+                            if (pieceLabel != null) {
+                                // 약간씩 오프셋 주기
+                                pieceLabel.setBounds(pos.x - 5 + (i * 5), pos.y - 35 - (i * 5), 40, 40);
+                                boardPanel.add(pieceLabel);
+                                boardPanel.setComponentZOrder(pieceLabel, i);
+                            }
+                        }
+                    }
+                }
+            }
+
+            // 화면 갱신
+            boardPanel.revalidate();
+            boardPanel.repaint();
         }
     
         // 윷 이미지 초기화 메서드
+        @Override
         public void clearYutImage() {
             yutResultLabel.setText("윷 결과: ");
             yutImageLabel.setIcon(null);
@@ -1025,7 +1094,18 @@
         public void setStatusMessage(String message) {
             statusMessageLabel.setText(message);
         }
-    
+
+        @Override
+        public void clearPieceSelection() {
+            // 모든 말의 테두리 제거
+            for (Map.Entry<String, JLabel> entry : playerPiecesMap.entrySet()) {
+                JLabel pieceLabel = entry.getValue();
+                pieceLabel.setBorder(null);
+            }
+            // 선택된 말 인덱스 초기화 (필요시)
+            this.selectedPieceIndex = -1;
+        }
+
         /**
          * 화면을 닫는 메서드
          */


### PR DESCRIPTION
# 구현 내용

1. 말 잡기 기능
말을 잡게 되면, 기존에 윷 판에 존재하던 플레이어의 말은 "플레이어 정보 패널" 로 다시 이동합니다. 잡힌 말은 언제든지 다시 사용할 수 있어야 하기 때문입니다.

--------------

3. 말 업기 기능
말이 업혀있는 경우, 숫자를 표시하여 몇 개의 말이 업혀있는지 표시하였습니다.
업힌 말을 어떻게 이미지로 표시할지 고민을 좀 해보았습니다.
이미 우리가 만들어놓았던 "플레이어1말2겹" 같은 이미지를 사용하는 것 보다는,
말이 업힐때마다 일정 간격을 두고 새로 추가된 말을 겹쳐서 표시하는 방법을 선택했습니다.
전자를 선택하는 경우 말 하나하나가 각각의 객체가 아니라, 두개가 합쳐진 이미지가 하나의 객체이기 때문에
추적이 어렵다고 판단했습니다.

-----------------
4. 기타 수정 사항
컨트롤러 일부 코드 수정하였습니다.