### PR TITLE
[FIX][UI] 화면에서 말이 최대 4개까지 업힐 수 있도록 수정

### DIFF
--- a/src/view/SwingPlayScreen.java
+++ b/src/view/SwingPlayScreen.java
@@ -1091,7 +1091,7 @@ public class SwingPlayScreen extends JFrame implements GamePlayView {
           stackCountLabels.add(stackCountLabel);
 
           // 나머지 말들은 살짝 겹쳐서 표시 (시각적 효과)
-          for (int i = 1; i < piecesAtCell.size() && i < 4; i++) { // 최대 3개까지만 표시
+          for (int i = 1; i < piecesAtCell.size() && i < 5; i++) { // 최대 4개까지
             PositionDTO dto = piecesAtCell.get(i);
             JLabel pieceLabel = playerPiecesMap.get(dto.getPlayerId() + "_" + dto.getPieceId());
 


### PR DESCRIPTION
게임설정화면에서, 말 개수를 최대 5개까지 설정할 수 있습니다.
기존에는 말 개수를 5개로 설정하였을때, 말을 업는 경우 최대 3개까지만 업을 수 있도록 표시되었습니다. 

이 문제를 수정하여, 최대 4개의 말을 업을 수 있도록 하였습니다.